### PR TITLE
MainController now takes a single argument that is the path to the configuration directory. Also, configuration files are now reloaded when leaving the Settings scene.

### DIFF
--- a/blade_runner/controllers/main_controller.py
+++ b/blade_runner/controllers/main_controller.py
@@ -110,11 +110,11 @@ class MainController(Controller):
 
         self._slack_data = plistlib.readPlist(self._slack_config_path)
 
-        verify_params_data = plistlib.readPlist(self._verify_config_path)
-        self.verify_params = VerifyParams(verify_params_data)
+        self._verify_params_data = plistlib.readPlist(self._verify_config_path)
+        self.verify_params = VerifyParams(self._verify_params_data)
 
-        search_params_data = plistlib.readPlist(self._search_config_path)
-        self.search_params = SearchParams(search_params_data)
+        self._search_params_data = plistlib.readPlist(self._search_config_path)
+        self.search_params = SearchParams(self._search_params_data)
 
         self._doc_settings = plistlib.readPlist(self._print_config_path)
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -140,20 +140,14 @@ class MainController(Controller):
         # Initialize offboard config.
         self._offboard_config = None
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-        # Save Verify/SearchParams original input
-        self._verify_params_arg = verify_params_data
-        self._search_params_arg = search_params_data
-        # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
         # Set path to config directory that contains the configuration files.
         app_root_dir = os.path.abspath(__file__)
         for i in range(3):
             app_root_dir = os.path.dirname(app_root_dir)
 
         self.app_root_dir = app_root_dir
-        # self._config_dir = os.path.join(self.app_root_dir, "config")
         self._blade_runner_dir = os.path.join(self.app_root_dir, "blade_runner")
         self._slack_dir = os.path.join(self._blade_runner_dir, "slack")
-        # self._offboard_configs_dir = os.path.join(self._config_dir, "offboard_configs")
         self._secure_erase_dir = os.path.join(self._blade_runner_dir, "secure_erase")
 
     def reload_configs(self):
@@ -164,26 +158,21 @@ class MainController(Controller):
         """
         if self._jamf_pro_config_path:
             jss_server_data = plistlib.readPlist(self._jamf_pro_config_path)
-            self.logger.debug(jss_server_data)
             self._jss_server = JssServer(**jss_server_data)
 
         if self._slack_config_path:
             self._slack_data = plistlib.readPlist(self._slack_config_path)
-            self.logger.debug(self._slack_data)
 
         if self._verify_config_path:
-            verify_params_data = plistlib.readPlist(self._verify_config_path)
-            self.logger.debug(verify_params_data)
-            self.verify_params = VerifyParams(verify_params_data)
+            self._verify_params_data = plistlib.readPlist(self._verify_config_path)
+            self.verify_params = VerifyParams(self._verify_params_data)
 
         if self._search_config_path:
-            search_params_data = plistlib.readPlist(self._search_config_path)
-            self.logger.debug(search_params_data)
-            self.search_params = SearchParams(search_params_data)
+            self._search_params_data = plistlib.readPlist(self._search_config_path)
+            self.search_params = SearchParams(self._search_params_data)
 
         if self._print_config_path:
             self._doc_settings = plistlib.readPlist(self._print_config_path)
-            self.logger.debug(self._doc_settings)
 
         self.logger.info("Reloaded configuration files.")
 
@@ -259,10 +248,10 @@ class MainController(Controller):
         self._computer = Computer()
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
         # Create a new VerifyParams object.
-        self.verify_params = VerifyParams(self._verify_params_arg)
+        self.verify_params = VerifyParams(self._verify_params_data)
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
         # Create a new SearchParams object.
-        self.search_params = SearchParams(self._search_params_arg)
+        self.search_params = SearchParams(self._search_params_data)
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
         self.logger.info("Blade-Runner reset.")
 

--- a/blade_runner/views/main_view.py
+++ b/blade_runner/views/main_view.py
@@ -399,6 +399,8 @@ class MainView(tk.Toplevel):
         # Settins scene logic
         elif self.curr_scene == "settings_scene":
             self._grid_forget_settings_scene()
+            # Reload configs before switching scenes.
+            self._controller.reload_configs()
             if self.prev_scene == "selection_scene":
                 self._selection_scene()
             elif self.prev_scene == "offboard_scene":
@@ -417,6 +419,10 @@ class MainView(tk.Toplevel):
         Returns:
             void
         """
+        # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+        # If the current scene is the settings scene, reload the configs before switching to the help scene.
+        if curr_scene == "settings_scene":
+            self._controller.reload_configs()
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
         # Set previous scene.
         if curr_scene != "help_scene":

--- a/test/config/python_bin_config/python_bin.plist
+++ b/test/config/python_bin_config/python_bin.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>python_binary</key>
+	<string>/usr/bin/python</string>
+</dict>
+</plist>

--- a/test/test_blade_runner_manual.py
+++ b/test/test_blade_runner_manual.py
@@ -32,7 +32,6 @@ Current working directory must be Blade Runner, as in Contents/Resources/Blade\ 
 import os
 import sys
 import logging
-import plistlib
 import unittest
 import subprocess
 import Tkinter as tk
@@ -41,7 +40,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "blade_runner/dependencies"))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "blade_runner/slack"))
 
-from blade_runner.jamf_pro.jss_server import JssServer
 from blade_runner.controllers.main_controller import MainController
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -60,29 +58,10 @@ class TestBladeRunnerManual(unittest.TestCase):
         abs_file_path = os.path.abspath(__file__)
         self.blade_runner_dir = os.path.dirname(abs_file_path)
         # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-        # Get Jamf Pro settings.
-        jss_server_plist = os.path.join(self.blade_runner_dir, "config/jamf_pro_configs/jamf_pro.plist")
-        jss_server_data = plistlib.readPlist(jss_server_plist)
-        jss_server = JssServer(**jss_server_data)
-
-        # Get Slack settings.
-        self.slack_plist = os.path.join(self.blade_runner_dir, "config/slack_configs/slack.plist")
-        self.slack_data = plistlib.readPlist(self.slack_plist)
-
-        # Get verification parameter settings
-        self.verify_config = os.path.join(self.blade_runner_dir, "config/verify_params_configs/verify_params.plist")
-        self.verify_data = plistlib.readPlist(self.verify_config)
-
-        # Get search parameter settings.
-        self.search_params_config = os.path.join(self.blade_runner_dir, "config/search_params_configs/search_params.plist")
-        self.search_params = plistlib.readPlist(self.search_params_config)
-
-        # Get document settings.
-        self.print_config = os.path.join(self.blade_runner_dir, "config/print_config/print.plist")
-        self.print_settings = plistlib.readPlist(self.print_config)
+        self.config_dir = os.path.join(self.blade_runner_dir, "config")
 
         # Set up main controller.
-        self.br = MainController(root, jss_server, self.slack_data, self.verify_data, self.search_params, self.print_settings)
+        self.br = MainController(root, self.config_dir)
 
     def test_manual(self):
         """Manually test Blade Runner."""


### PR DESCRIPTION
`__init__` in `MainController` now takes a path to the configuration directory instead of specifying the path to each config. `MainController` is meant to be used with a configuration directory, hence the switch.

This change allows all test configs to be opened through settings when running `test_blade_runner_manual.py`, which wasn't the case previously.

Updated `test_blade_runner_manual.py` to be compatible with these changes.

Added `_reload_configs()`. Reloads configuration files in the configuration directory.

`MainView` has been updated to call `_reload_configs()` when the *settings scene* is left. This essentially ensures that the configs are reloaded if any changes are made. Before this commit, the only way to reload the configs was to quit *Blade Runner* and start it up again.

**Fixed restart bug**:

BUG: When `restart()` is called, `_verify_params_arg` and `_search_params_arg` are used to reset `verify_params` and `search_params`. This is a problem if the *search/verification params* have been updated through settings, since `reload_configs()` doesn't update `_verify_params_arg` or `_search_params_arg`.
    
FIX: `reload_configs()` now saves the data from the configuration files that are used to reinitialize `SearchParams` and `VerifyParams`. `restart()` uses that data to reinitialize `verify_params` and `search_params` instead of using `_verify_params_arg` and `search_params_arg`.